### PR TITLE
fix(cograph): use function instead of non-existing method call

### DIFF
--- a/tests/cograph_tests.py
+++ b/tests/cograph_tests.py
@@ -7,6 +7,7 @@ from tralda.cograph import random_cotree
 from tralda.cograph import to_cograph
 from tralda.cograph import to_cotree
 from tralda.cograph import CographEditor
+from tralda.cograph import edit_to_cograph
 from tralda.cograph import complete_multipartite_completion
 
 import tralda.utils.graph_tools as gt
@@ -36,6 +37,11 @@ class TestCographPackage(unittest.TestCase):
         self.assertGreater(ce.best_cost, 0)
 
     def test_editing(self):
+        graph = gt.random_graph(100, p=0.3)
+        cograph = edit_to_cograph(graph)
+        self.assertTrue(to_cotree(cograph))
+
+    def test_editing_class(self):
         graph = gt.random_graph(100, p=0.3)
         ce = CographEditor(graph)
         ce.cograph_edit(run_number=10)

--- a/tralda/cograph/editing.py
+++ b/tralda/cograph/editing.py
@@ -11,6 +11,7 @@ from typing import Any
 
 import networkx as nx
 
+from tralda.cograph.functions import to_cograph
 from tralda.datastructures.tree import Tree
 from tralda.datastructures.tree import TreeNode
 
@@ -35,7 +36,7 @@ def edit_to_cograph(graph, run_number: int = 10) -> nx.Graph:
     ce = CographEditor(graph)
     best_cotree = ce.cograph_edit(run_number=run_number)
 
-    return best_cotree.to_cograph()
+    return to_cograph(best_cotree)
 
 
 class CographEditor:


### PR DESCRIPTION
The function `edit_to_cograph` used a non-existent method `to_cograph` of class `Tree`. It now uses the function `to_cograph` from `tralda.cograph.functions`.